### PR TITLE
"-" and "_" are valid characters in module names

### DIFF
--- a/libraries/selinux_file_helper.rb
+++ b/libraries/selinux_file_helper.rb
@@ -29,7 +29,7 @@ module SELinux
         line.chomp
 
         # extracting version and module name
-        if (match = line.match(/^module\s+(\w+)\s+([\d\.\-]+);/))
+        if (match = line.match(/^module\s+([\w_-]+)\s+([\d\.\-]+);/))
           @module_name, @version = match.captures
         end
 


### PR DESCRIPTION
Without this change, modules with "_" or "-" in their name will have their name truncated on parsing, resulting in either

a.) always rebuilding (since no module with the truncated name is present), breaking idempotency

b.) never rebuilding (since the truncated name matches an existing module), breaking installation

Signed-off-by: Jim Wise <jwise@draga.com>

### Description

Fixes idempotency and installation for modules with "-" or "_" in their name.

### Issues Resolved

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [N/A] New functionality has been documented in the README if applicable
- [?] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>