### PR TITLE
Correctly parse ports with multiple contexts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
   integration:
     needs: [mdl, yamllint, delivery]
-    runs-on: macos-latest
+    runs-on: macos-10.15
     strategy:
       matrix:
         os:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the selinux cookbook.
 
 ## Unreleased
 
+- Correctly parse ports with multple contexts
+
 ## 6.0.0 - *2021-09-02*
 
 - Import `selinux_policy` resources into this cookbook (`_fcontext`, `_permissive`, and `_port`)

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,8 +3,8 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_zero
-  product_name: chef
+  name: chef_infra
+  product_name: <%= ENV['CHEF_PRODUCT_NAME'] || 'chef' %>
   chef_license: accept-no-persist
   multiple_converge: 2
   enforce_idempotency: true

--- a/resources/port.rb
+++ b/resources/port.rb
@@ -41,7 +41,7 @@ action_class do
         seinfo --portcon=#{new_resource.port} | grep 'portcon #{new_resource.protocol}' | \
         awk -F: '$(NF-1) !~ /reserved_port_t$/ && $(NF-3) !~ /[0-9]*-[0-9]*/ {print $(NF-1)}'
       CMD
-    ).stdout.strip
+    ).stdout.split
   end
 end
 
@@ -76,7 +76,7 @@ action :modify do
     return
   end
 
-  if !current_port_context.empty? && current_port_context != new_resource.secontext
+  if !current_port_context.empty? && !current_port_context.include?(new_resource.secontext)
     converge_by "Modifying context #{new_resource.secontext} to port #{new_resource.port}/#{new_resource.protocol}" do
       shell_out!("semanage port -m -t '#{new_resource.secontext}' -p #{new_resource.protocol} #{new_resource.port}")
     end

--- a/spec/unit/resources/port_spec.rb
+++ b/spec/unit/resources/port_spec.rb
@@ -82,4 +82,26 @@ describe 'selinux_port' do
     it { is_expected.to modify_selinux_port('1234') }
     it { is_expected.to delete_selinux_port('1234') }
   end
+
+  context 'when port has multiple contexts' do
+    stubs_for_provider('selinux_port[1234]') do |provider|
+      allow(provider).to receive_shell_out(<<~CMD, stdout: "test_t\nother_t")
+        seinfo --portcon=1234 | grep 'portcon tcp' | \
+        awk -F: '$(NF-1) !~ /reserved_port_t$/ && $(NF-3) !~ /[0-9]*-[0-9]*/ {print $(NF-1)}'
+      CMD
+    end
+
+    # this is what actually checks that the port was set correctly
+    # incorrect commands would not be stubbed and would throw error
+    stubs_for_provider('selinux_port[1234]') do |provider|
+      # when set correctly, only delete calls (-d) should happen
+      allow(provider).to receive_shell_out('semanage port -d -p tcp 1234')
+    end
+
+    # needed to have the test run
+    it { is_expected.to manage_selinux_port('1234') }
+    it { is_expected.to add_selinux_port('1234') }
+    it { is_expected.to modify_selinux_port('1234') }
+    it { is_expected.to delete_selinux_port('1234') }
+  end
 end

--- a/test/cookbooks/selinux_test/recipes/port.rb
+++ b/test/cookbooks/selinux_test/recipes/port.rb
@@ -9,3 +9,10 @@ selinux_port '29001' do
   protocol 'tcp'
   secontext 'ssh_port_t'
 end
+
+%w(8080 8081).each do |port|
+  selinux_port port do
+    protocol 'tcp'
+    secontext 'http_port_t'
+  end
+end

--- a/test/integration/port/controls/port_control.rb
+++ b/test/integration/port/controls/port_control.rb
@@ -3,19 +3,11 @@ include_controls 'common'
 control 'port' do
   title 'Verify that SELinux port contexts are set correctly'
 
-  describe command('seinfo --portcon=29000') do
+  describe command('seinfo --portcon') do
     its('stdout') { should match 'portcon tcp 29000 system_u:object_r:http_port_t:s0' }
     its('stdout') { should match 'portcon udp 29000 system_u:object_r:http_port_t:s0' }
-  end
-
-  describe command('seinfo --portcon=29001') do
     its('stdout') { should match 'portcon tcp 29001 system_u:object_r:ssh_port_t:s0' }
-  end
-
-  describe command('seinfo --portcon=8080') do
-    its('stdout') { should match 'portcon tcp 8080 system_u:object_r:ssh_port_t:s0' }
-  end
-  describe command('seinfo --portcon=8081') do
-    its('stdout') { should match 'portcon tcp 8081 system_u:object_r:ssh_port_t:s0' }
+    its('stdout') { should match 'portcon tcp 8080 system_u:object_r:http_port_t:s0' }
+    its('stdout') { should match 'portcon tcp 8081 system_u:object_r:http_port_t:s0' }
   end
 end

--- a/test/integration/port/controls/port_control.rb
+++ b/test/integration/port/controls/port_control.rb
@@ -11,4 +11,11 @@ control 'port' do
   describe command('seinfo --portcon=29001') do
     its('stdout') { should match 'portcon tcp 29001 system_u:object_r:ssh_port_t:s0' }
   end
+
+  describe command('seinfo --portcon=8080') do
+    its('stdout') { should match 'portcon tcp 8080 system_u:object_r:ssh_port_t:s0' }
+  end
+  describe command('seinfo --portcon=8081') do
+    its('stdout') { should match 'portcon tcp 8081 system_u:object_r:ssh_port_t:s0' }
+  end
 end


### PR DESCRIPTION
Signed-off-by: Robert Detjens <detjensrobert@osuosl.org>

# Description

If a port has multiple contexts assigned (e.g. adding `httpd` to `8080`), `selinux_port` did not correctly recognize that and always assumed there was a single context, causing idempotency errors. 

This fixes this and now handles multiple contexts correctly and was causing idempotency errors.

## Issues Resolved

(none)

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
