### PR TITLE
Fix kitchen test failures on centos6 for chef16/17 in chef's CI pipeline 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This file is used to list changes made in each version of the selinux cookbook.
 ## Unreleased
 
 - Fix CentOS 6 package requirements
-- Lock CI testing to Chef 17 now that 18 includes native resources
+- Fix Chef 18 compatibility
 
 ## 6.0.6 - *2022-09-28*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file is used to list changes made in each version of the selinux cookbook.
 
 ## Unreleased
 
+- Fix CentOS 6 package requirements
+- Lock CI testing to Chef 17 now that 18 includes native resources
+
 ## 6.0.6 - *2022-09-28*
 
 - Add missing `policycoreutils-python` package

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -9,7 +9,7 @@ provisioner:
   multiple_converge: 2
   enforce_idempotency: true
   deprecations_as_errors: true
-  product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
+  product_version: <%= ENV['CHEF_VERSION'] || '17' %>
   log_level: <%= ENV['CHEF_LOG_LEVEL'] || 'auto' %>
   # Allow reboots
   max_retries: 60

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -9,7 +9,7 @@ provisioner:
   multiple_converge: 2
   enforce_idempotency: true
   deprecations_as_errors: true
-  product_version: <%= ENV['CHEF_VERSION'] || '17' %>
+  product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   log_level: <%= ENV['CHEF_LOG_LEVEL'] || 'auto' %>
   # Allow reboots
   max_retries: 60

--- a/libraries/install.rb
+++ b/libraries/install.rb
@@ -5,6 +5,8 @@ module SELinux
         case node['platform_family']
         when 'rhel'
           case node['platform_version'].to_i
+          when 6
+            %w(make policycoreutils selinux-policy selinux-policy-targeted selinux-policy-devel libselinux-utils setools-console)
           when 7
             %w(make policycoreutils policycoreutils-python selinux-policy selinux-policy-targeted selinux-policy-devel libselinux-utils setools-console)
           else

--- a/resources/boolean.rb
+++ b/resources/boolean.rb
@@ -24,7 +24,7 @@ property :boolean, String,
 property :value, [Integer, String, true, false],
           required: true,
           equal_to: %w(on off),
-          coerce: proc { |p| SELinux::Cookbook::BooleanHelpers.selinux_bool(p) },
+          coerce: proc { |p| ::SELinux::Cookbook::BooleanHelpers.selinux_bool(p) },
           description: 'SELinux boolean value'
 
 property :persistent, [true, false],
@@ -37,7 +37,7 @@ load_current_value do |new_resource|
 end
 
 action_class do
-  include SELinux::Cookbook::StateHelpers
+  include ::SELinux::Cookbook::StateHelpers
 end
 
 action :set do

--- a/resources/fcontext.rb
+++ b/resources/fcontext.rb
@@ -31,7 +31,7 @@ property :file_type, String,
           description: 'The type of the file being labeled'
 
 action_class do
-  include SELinux::Cookbook::StateHelpers
+  include ::SELinux::Cookbook::StateHelpers
 
   def current_file_context
     file_hash = {

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -18,7 +18,7 @@
 
 unified_mode true
 
-include SELinux::Cookbook::InstallHelpers
+include ::SELinux::Cookbook::InstallHelpers
 
 property :packages, [String, Array],
           default: lazy { default_install_packages },

--- a/resources/port.rb
+++ b/resources/port.rb
@@ -32,7 +32,7 @@ property :secontext, String,
           description: 'SELinux context to assign to the port'
 
 action_class do
-  include SELinux::Cookbook::StateHelpers
+  include ::SELinux::Cookbook::StateHelpers
 
   def current_port_context
     # use awk to see if the given port is within a reported port range

--- a/resources/state.rb
+++ b/resources/state.rb
@@ -18,7 +18,7 @@
 
 unified_mode true
 
-include SELinux::Cookbook::StateHelpers
+include ::SELinux::Cookbook::StateHelpers
 
 default_action :nothing
 
@@ -41,7 +41,7 @@ property :automatic_reboot, [true, false, Symbol],
 deprecated_property_alias 'temporary', 'persistent', 'The temporary property was renamed persistent in the 4.0 release of this cookbook. Please update your cookbooks to use the new property name.'
 
 action_class do
-  include SELinux::Cookbook::StateHelpers
+  include ::SELinux::Cookbook::StateHelpers
 
   def render_selinux_template(action)
     Chef::Log.warn(


### PR DESCRIPTION

Signed-off-by: Neha Pansare <neha.pansare@progress.com>

# Description

Centos6 doesnot support policycoreutils packages. Update condition so as not to use them on centos6.

## Issues Resolved

https://github.com/sous-chefs/selinux/issues/88

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
