### PR TITLE
Add selinux_user and selinux_login resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ This file is used to list changes made in each version of the selinux cookbook.
 - resolved cookstyle error: resources/install.rb:5:1 refactor: `Chef/Style/CopyrightCommentFormat`
 - resolved cookstyle error: resources/module.rb:5:1 refactor: `Chef/Style/CopyrightCommentFormat`
 - resolved cookstyle error: resources/state.rb:5:1 refactor: `Chef/Style/CopyrightCommentFormat`
-Standardise files with files in sous-chefs/repo-management
+- Standardise files with files in sous-chefs/repo-management
+- Add `selinux_login` resource
+- Add `selinux_user` resource
 
 ## 6.0.7 - *2022-11-01*
 

--- a/README.md
+++ b/README.md
@@ -46,10 +46,12 @@ The following resources are provided:
 - [selinux_boolean](documentation/selinux_boolean.md)
 - [selinux_fcontext](documentation/selinux_fcontext.md)
 - [selinux_install](documentation/selinux_install.md)
+- [selinux_login](documentation/selinux_login.md)
 - [selinux_module](documentation/selinux_module.md)
 - [selinux_permissive](documentation/selinux_permissive.md)
 - [selinux_port](documentation/selinux_port.md)
 - [selinux_state](documentation/selinux_state.md)
+- [selinux_user](documentation/selinux_user.md)
 
 ## Maintainers
 

--- a/documentation/selinux_login.md
+++ b/documentation/selinux_login.md
@@ -1,0 +1,37 @@
+[Back to resource list](../README.md#resources)
+
+# selinux_login
+
+The `selinux_login` resource is used to manage Linux user to SELinux user mappings on the system.
+
+## Actions
+
+| Action    | Description                                                                                      |
+| --------- | ------------------------------------------------------------------------------------------------ |
+| `:manage` | *(Default)* Sets the SELinux login mapping to the desired settings regardless of previous state. |
+| `:add`    | Creates the SELinux login mapping if not created.(`-a`)                                          |
+| `:modify` | Updates the SELinux login mapping if previously created.(`-m`)                                   |
+| `:delete` | Removes the SELinux login mapping if previously created. (`-d`)                                  |
+
+## Properties
+
+| Name    | Type   | Default       | Description                          |
+| ------- | ------ | ------------- | ------------------------------------ |
+| `login` | String | Resource name | The OS user login.                   |
+| `user`  | String |               | The SELinux user.                    |
+| `range` | String |               | MLS/MCS security range for the user. |
+
+## Examples
+
+```ruby
+# Manage myuser OS user mapping with a range of s0 and associated SELinux user myuser_u
+selinux_login 'myuser' do
+  user 'myuser_u'
+  range 's0'
+end
+
+# Manage myuser OS user mapping using the default system range and associated SELinux user myuser_u
+selinux_login 'myuser' do
+  user 'myuser_u'
+end
+```

--- a/documentation/selinux_user.md
+++ b/documentation/selinux_user.md
@@ -1,0 +1,39 @@
+[Back to resource list](../README.md#resources)
+
+# selinux_user
+
+The `selinux_user` resource is used to manage SELinux users on the system.
+
+## Actions
+
+| Action    | Description                                                                             |
+| --------- | --------------------------------------------------------------------------------------- |
+| `:manage` | *(Default)* Sets the SELinux user to the desired settings regardless of previous state. |
+| `:add`    | Creates the SELinux user if not created.(`-a`)                                          |
+| `:modify` | Updates the SELinux user if previously created.(`-m`)                                   |
+| `:delete` | Removes the SELinux user if previously created. (`-d`)                                  |
+
+## Properties
+
+| Name    | Type   | Default       | Description                                         |
+| ------- | ------ | ------------- | --------------------------------------------------- |
+| `user`  | String | Resource name | The SELinux user.                                   |
+| `level` | String |               | MLS/MCS security level for the user.                |
+| `range` | String |               | MLS/MCS security range for the user.                |
+| `roles` | Array  |               | SELinux roles for the user (required for creation). |
+
+## Examples
+
+```ruby
+# Manage myuser_u SELinux user with a level and range of s0 and roles sysadm_r and staff_r
+selinux_user 'myuser_u' do
+  level 's0'
+  range 's0'
+  roles %w(sysadm_r staff_r)
+end
+
+# Manage myuser_u SELinux user using the default system level and range and roles sysadm_r and staff_r
+selinux_user 'myuser_u' do
+  roles %w(sysadm_r staff_r)
+end
+```

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -72,3 +72,9 @@ suites:
       - recipe[selinux_test::install]
       - recipe[selinux::permissive]
       - recipe[selinux_test::permissive_resource]
+  - name: user_login_mapping
+    run_list:
+      - recipe[selinux_test::install]
+      - recipe[selinux::permissive]
+      - recipe[selinux_test::user]
+      - recipe[selinux_test::login]

--- a/resources/login.rb
+++ b/resources/login.rb
@@ -1,0 +1,88 @@
+#
+# Cookbook:: selinux
+# Resource:: login
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+unified_mode true
+
+property :login, String,
+          name_property: true,
+          description: 'OS user login'
+
+property :user, String,
+          description: 'SELinux user'
+
+property :range, String,
+          description: 'MLS/MCS security range for the login'
+
+load_current_value do |new_resource|
+  logins = shell_out!('semanage login -l').stdout.split("\n")
+
+  current_login = logins.grep(/^#{Regexp.escape(new_resource.login)}\s+/) do |l|
+    l.match(/^(?<login>[^\s]+)\s+(?<user>[^\s]+)\s+(?<range>[^\s]+)/)
+    # match returns [<Match 'data'>] or [], shift converts that to <Match 'data'> or nil
+  end.shift
+
+  current_value_does_not_exist! unless current_login
+
+  # Existing resources should maintain their current configuration unless otherwise specified
+  new_resource.user ||= current_login[:user]
+  new_resource.range ||= current_login[:range]
+
+  user current_login[:user]
+  range current_login[:range]
+end
+
+action_class do
+  def semanage_login_args
+    args = ''
+
+    args += " -s #{new_resource.user}" if new_resource.user
+    args += " -r #{new_resource.range}" if new_resource.range
+
+    args
+  end
+end
+
+action :manage do
+  run_action(:add)
+  run_action(:modify)
+end
+
+action :add do
+  raise 'The user property must be populated to create a new SELinux login' unless new_resource.user
+
+  unless current_resource
+    converge_if_changed do
+      shell_out!("semanage login -a#{semanage_login_args} #{new_resource.login}")
+    end
+  end
+end
+
+action :modify do
+  if current_resource
+    converge_if_changed do
+      shell_out!("semanage login -m#{semanage_login_args} #{new_resource.login}")
+    end
+  end
+end
+
+action :delete do
+  if current_resource
+    converge_by "deleting SELinux login #{new_resource.login}" do
+      shell_out!("semanage login -d #{new_resource.login}")
+    end
+  end
+end

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -1,0 +1,95 @@
+#
+# Cookbook:: selinux
+# Resource:: user
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+unified_mode true
+
+property :user, String,
+          name_property: true,
+          description: 'SELinux user'
+
+property :level, String,
+          description: 'MLS/MCS security level for the user'
+
+property :range, String,
+          description: 'MLS/MCS security range for the user'
+
+property :roles, Array,
+          description: 'SELinux roles for the user'
+
+load_current_value do |new_resource|
+  users = shell_out!('semanage user -l').stdout.split("\n")
+
+  current_user = users.grep(/^#{Regexp.escape(new_resource.user)}\s+/) do |u|
+    u.match(/^(?<user>[^\s]+)\s+(?<prefix>[^\s]+)\s+(?<level>[^\s]+)\s+(?<range>[^\s]+)\s+(?<roles>.*)$/)
+    # match returns [<Match 'data'>] or [], shift converts that to <Match 'data'> or nil
+  end.shift
+
+  current_value_does_not_exist! unless current_user
+
+  # Existing resources should maintain their current configuration unless otherwise specified
+  new_resource.level ||= current_user[:level]
+  new_resource.range ||= current_user[:range]
+  new_resource.roles ||= current_user[:roles].to_s.split
+  new_resource.roles = new_resource.roles.sort
+
+  level current_user[:level]
+  range current_user[:range]
+  roles current_user[:roles].to_s.split.sort
+end
+
+action_class do
+  def semanage_user_args
+    args = ''
+
+    args += " -L #{new_resource.level}" if new_resource.level
+    args += " -r #{new_resource.range}" if new_resource.range
+    args += " -R '#{new_resource.roles.join(' ')}'" unless new_resource.roles.to_a.empty?
+
+    args
+  end
+end
+
+action :manage do
+  run_action(:add)
+  run_action(:modify)
+end
+
+action :add do
+  raise 'The roles property must be populated to create a new SELinux user' if new_resource.roles.to_a.empty?
+
+  unless current_resource
+    converge_if_changed do
+      shell_out!("semanage user -a#{semanage_user_args} #{new_resource.user}")
+    end
+  end
+end
+
+action :modify do
+  if current_resource
+    converge_if_changed do
+      shell_out!("semanage user -m#{semanage_user_args} #{new_resource.user}")
+    end
+  end
+end
+
+action :delete do
+  if current_resource
+    converge_by "deleting SELinux user #{new_resource.user}" do
+      shell_out!("semanage user -d #{new_resource.user}")
+    end
+  end
+end

--- a/spec/unit/resources/login_spec.rb
+++ b/spec/unit/resources/login_spec.rb
@@ -1,0 +1,107 @@
+require 'spec_helper'
+
+describe 'login' do
+  step_into :selinux_login
+  platform 'centos'
+
+  recipe do
+    selinux_login 'oslogin' do
+      user 'seuser'
+      range 's0'
+      action %i(manage add modify delete)
+    end
+  end
+
+  context 'when not set' do
+    stubs_for_resource('selinux_login[oslogin]') do |resource|
+      allow(resource).to receive_shell_out('semanage login -l', stdout: '')
+    end
+
+    # this is what actually checks that the login was set correctly
+    # incorrect commands would not be stubbed and would throw error
+    stubs_for_provider('selinux_login[oslogin]') do |provider|
+      # when not set, only add calls (-a) should happen
+      allow(provider).to receive_shell_out('semanage login -a -s seuser -r s0 oslogin')
+    end
+
+    # needed to have the test run
+    it { is_expected.to manage_selinux_login('oslogin') }
+    it { is_expected.to add_selinux_login('oslogin') }
+    it { is_expected.to modify_selinux_login('oslogin') }
+    it { is_expected.to delete_selinux_login('oslogin') }
+  end
+
+  context 'when set to incorrect value' do
+    stubs_for_resource('selinux_login[oslogin]') do |resource|
+      allow(resource).to receive_shell_out(
+        'semanage login -l',
+        stdout: <<~STDOUT
+          Login Name           SELinux User         MLS/MCS Range        Service
+
+          __default__          unconfined_u         s0-s0:c0.c1023       *
+          root                 unconfined_u         s0-s0:c0.c1023       *
+          oslogin              unconfined_u         s0-s0:c0.c1023       *
+        STDOUT
+      )
+    end
+
+    # this is what actually checks that the login was set correctly
+    # incorrect commands would not be stubbed and would throw error
+    stubs_for_provider('selinux_login[oslogin]') do |provider|
+      # when set incorrectly, only modify calls (-m) and delete calls (-d) should happen
+      allow(provider).to receive_shell_out('semanage login -m -s seuser -r s0 oslogin')
+      allow(provider).to receive_shell_out('semanage login -d oslogin')
+    end
+
+    # needed to have the test run
+    it { is_expected.to manage_selinux_login('oslogin') }
+    it { is_expected.to add_selinux_login('oslogin') }
+    it { is_expected.to modify_selinux_login('oslogin') }
+    it { is_expected.to delete_selinux_login('oslogin') }
+  end
+
+  context 'when set to correct value' do
+    stubs_for_resource('selinux_login[oslogin]') do |resource|
+      allow(resource).to receive_shell_out(
+        'semanage login -l',
+        stdout: <<~STDOUT
+          Login Name           SELinux User         MLS/MCS Range        Service
+
+          __default__          unconfined_u         s0-s0:c0.c1023       *
+          root                 unconfined_u         s0-s0:c0.c1023       *
+          oslogin              seuser               s0                   *
+        STDOUT
+      )
+    end
+
+    # this is what actually checks that the login was set correctly
+    # incorrect commands would not be stubbed and would throw error
+    stubs_for_provider('selinux_login[oslogin]') do |provider|
+      # when set correctly, only delete calls (-d) should happen
+      allow(provider).to receive_shell_out('semanage login -d oslogin')
+    end
+
+    # needed to have the test run
+    it { is_expected.to manage_selinux_login('oslogin') }
+    it { is_expected.to add_selinux_login('oslogin') }
+    it { is_expected.to modify_selinux_login('oslogin') }
+    it { is_expected.to delete_selinux_login('oslogin') }
+  end
+
+  context 'when user property is unset' do
+    recipe do
+      selinux_login 'oslogin' do
+        range 's0'
+        action %i(manage add)
+      end
+    end
+
+    stubs_for_resource('selinux_login[oslogin]') do |resource|
+      allow(resource).to receive_shell_out('semanage login -l', stdout: '')
+    end
+
+    it 'raises an exception' do
+      expect { chef_run }.to raise_error(/user property must be populated/)
+    end
+  end
+end

--- a/spec/unit/resources/user_spec.rb
+++ b/spec/unit/resources/user_spec.rb
@@ -1,0 +1,123 @@
+require 'spec_helper'
+
+describe 'user' do
+  step_into :selinux_user
+  platform 'centos'
+
+  recipe do
+    selinux_user 'seuser' do
+      level 's0'
+      range 's0'
+      roles %w(staff_r sysadm_r)
+      action %i(manage add modify delete)
+    end
+  end
+
+  context 'when not set' do
+    stubs_for_resource('selinux_user[seuser]') do |resource|
+      allow(resource).to receive_shell_out('semanage user -l', stdout: '')
+    end
+
+    # this is what actually checks that the user was set correctly
+    # incorrect commands would not be stubbed and would throw error
+    stubs_for_provider('selinux_user[seuser]') do |provider|
+      # when not set, only add calls (-a) should happen
+      allow(provider).to receive_shell_out("semanage user -a -L s0 -r s0 -R 'staff_r sysadm_r' seuser")
+    end
+
+    # needed to have the test run
+    it { is_expected.to manage_selinux_user('seuser') }
+    it { is_expected.to add_selinux_user('seuser') }
+    it { is_expected.to modify_selinux_user('seuser') }
+    it { is_expected.to delete_selinux_user('seuser') }
+  end
+
+  context 'when set to incorrect value' do
+    stubs_for_resource('selinux_user[seuser]') do |resource|
+      allow(resource).to receive_shell_out(
+        'semanage user -l',
+        stdout: <<~STDOUT
+                          Labeling   MLS/       MLS/
+          SELinux User    Prefix     MCS Level  MCS Range                      SELinux Roles
+
+          guest_u         user       s0         s0                             guest_r
+          root            user       s0         s0-s0:c0.c1023                 staff_r sysadm_r system_r unconfined_r
+          staff_u         user       s0         s0-s0:c0.c1023                 staff_r sysadm_r system_r unconfined_r
+          seuser          user       s0         s0-s0:c0.c1023                 staff_r sysadm_r system_r unconfined_r
+          sysadm_u        user       s0         s0-s0:c0.c1023                 sysadm_r
+          system_u        user       s0         s0-s0:c0.c1023                 system_r unconfined_r
+          unconfined_u    user       s0         s0-s0:c0.c1023                 system_r unconfined_r
+          user_u          user       s0         s0                             user_r
+          xguest_u        user       s0         s0                             xguest_r
+        STDOUT
+      )
+    end
+
+    # this is what actually checks that the user was set correctly
+    # incorrect commands would not be stubbed and would throw error
+    stubs_for_provider('selinux_user[seuser]') do |provider|
+      # when set incorrectly, only modify calls (-m) and delete calls (-d) should happen
+      allow(provider).to receive_shell_out("semanage user -m -L s0 -r s0 -R 'staff_r sysadm_r' seuser")
+      allow(provider).to receive_shell_out('semanage user -d seuser')
+    end
+
+    # needed to have the test run
+    it { is_expected.to manage_selinux_user('seuser') }
+    it { is_expected.to add_selinux_user('seuser') }
+    it { is_expected.to modify_selinux_user('seuser') }
+    it { is_expected.to delete_selinux_user('seuser') }
+  end
+
+  context 'when set to correct value' do
+    stubs_for_resource('selinux_user[seuser]') do |resource|
+      allow(resource).to receive_shell_out(
+        'semanage user -l',
+        stdout: <<~STDOUT
+                          Labeling   MLS/       MLS/
+          SELinux User    Prefix     MCS Level  MCS Range                      SELinux Roles
+
+          guest_u         user       s0         s0                             guest_r
+          root            user       s0         s0-s0:c0.c1023                 staff_r sysadm_r system_r unconfined_r
+          staff_u         user       s0         s0-s0:c0.c1023                 staff_r sysadm_r system_r unconfined_r
+          seuser          user       s0         s0                             staff_r sysadm_r
+          sysadm_u        user       s0         s0-s0:c0.c1023                 sysadm_r
+          system_u        user       s0         s0-s0:c0.c1023                 system_r unconfined_r
+          unconfined_u    user       s0         s0-s0:c0.c1023                 system_r unconfined_r
+          user_u          user       s0         s0                             user_r
+          xguest_u        user       s0         s0                             xguest_r
+        STDOUT
+      )
+    end
+
+    # this is what actually checks that the user was set correctly
+    # incorrect commands would not be stubbed and would throw error
+    stubs_for_provider('selinux_user[seuser]') do |provider|
+      # when set correctly, only delete calls (-d) should happen
+      allow(provider).to receive_shell_out('semanage user -d seuser')
+    end
+
+    # needed to have the test run
+    it { is_expected.to manage_selinux_user('seuser') }
+    it { is_expected.to add_selinux_user('seuser') }
+    it { is_expected.to modify_selinux_user('seuser') }
+    it { is_expected.to delete_selinux_user('seuser') }
+  end
+
+  context 'when roles property is unset' do
+    recipe do
+      selinux_user 'seuser' do
+        level 's0'
+        range 's0'
+        action %i(manage add)
+      end
+    end
+
+    stubs_for_resource('selinux_user[seuser]') do |resource|
+      allow(resource).to receive_shell_out('semanage user -l', stdout: '')
+    end
+
+    it 'raises an exception' do
+      expect { chef_run }.to raise_error(/roles property must be populated/)
+    end
+  end
+end

--- a/test/cookbooks/selinux_test/recipes/login.rb
+++ b/test/cookbooks/selinux_test/recipes/login.rb
@@ -1,0 +1,11 @@
+user 'test1'
+user 'test2'
+
+selinux_login 'test1' do
+  user 'test1_u'
+  range 's0'
+end
+
+selinux_login 'test2' do
+  user 'test2_u'
+end

--- a/test/cookbooks/selinux_test/recipes/user.rb
+++ b/test/cookbooks/selinux_test/recipes/user.rb
@@ -1,0 +1,9 @@
+selinux_user 'test1_u' do
+  level 's0'
+  range 's0-s0:c0.c1023'
+  roles %w(unconfined_r staff_r sysadm_r)
+end
+
+selinux_user 'test2_u' do
+  roles %w(staff_r)
+end

--- a/test/integration/user_login_mapping/controls/user_login_mapping_control.rb
+++ b/test/integration/user_login_mapping/controls/user_login_mapping_control.rb
@@ -1,0 +1,19 @@
+include_controls 'common'
+
+control 'user' do
+  title 'Verify that SELinux user are set correctly'
+
+  describe command('semanage user -l') do
+    its('stdout') { should match /^test1_u\s+user\s+s0\s+s0-s0:c0\.c1023\s+staff_r sysadm_r unconfined_r/ }
+    its('stdout') { should match /^test2_u\s+user\s+s0\s+s0\s+staff_r\s*$/ }
+  end
+end
+
+control 'login' do
+  title 'Verify that SELinux login mappings are set correctly'
+
+  describe command('semanage login -l') do
+    its('stdout') { should match /^test1\s+test1_u\s+s0\s*\*?\s*$/ }
+    its('stdout') { should match /^test2\s+test2_u\s+s0\s*\*?\s*$/ }
+  end
+end

--- a/test/integration/user_login_mapping/inspec.yml
+++ b/test/integration/user_login_mapping/inspec.yml
@@ -1,0 +1,7 @@
+---
+name: user_login_mapping
+title: User and login mapping suite tests for the SELinux cookbook
+
+depends:
+  - name: common
+    path: test/integration/common


### PR DESCRIPTION
# Description

* Adds `selinux_user` resource to manage SELinux users.
    * Manages user security level, range, and roles.
* Adds `selinux_login` resource to manage OS login to SELinux user mapping.
    * Manages OS to SELinux user mapping and associated range.

Please let me know if any changes are needed or if these resources are not an appropriate fit for the selinux cookbook.

## Issues Resolved

N/A, new feature

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
