### PR TITLE
Update selinux_port.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the selinux cookbook.
 
 ## Unreleased
 
+- Updated selinux_port documentation
+
 ## 6.1.0 - *2023-01-18*
 
 - resolved cookstyle error: resources/install.rb:5:1 refactor: `Chef/Style/CopyrightCommentFormat`

--- a/documentation/selinux_port.md
+++ b/documentation/selinux_port.md
@@ -1,6 +1,6 @@
 [Back to resource list](../README.md#resources)
 
-# selinux_policy_port
+# selinux_port
 
 Allows assigning a network port to a certain SELinux context, e.g. for running a webserver on a non-standard port.
 
@@ -25,7 +25,7 @@ Allows assigning a network port to a certain SELinux context, e.g. for running a
 
 ```ruby
 # Allow nginx/apache to bind to port 5678 by giving it the http_port_t context
-selinux_policy_port '5678' do
+selinux_port '5678' do
  protocol 'tcp'
  secontext 'http_port_t'
 end


### PR DESCRIPTION
Update to reflect selinux_port resource rename

# Description

Quick fix for documentation for `selinux_port` back from https://github.com/sous-chefs/selinux/pull/79