### PR TITLE
Fix examples for `selinux_fcontext`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the selinux cookbook.
 
 ## Unreleased
 
+- fix documentation for `selinux_fcontext`
+
 ## 6.2.0 - *2024-07-15*
 
 ## 6.1.19 - *2024-07-15*

--- a/documentation/selinux_fcontext.md
+++ b/documentation/selinux_fcontext.md
@@ -36,12 +36,12 @@ Supported file types:
 
 ```ruby
 # Allow http servers (e.g. nginx/apache) to modify moodle files
-selinux_policy_fcontext '/var/www/moodle(/.*)?' do
+selinux_fcontext '/var/www/moodle(/.*)?' do
   secontext 'httpd_sys_rw_content_t'
 end
 
 # Adapt a symbolic link
-selinux_policy_fcontext '/var/www/symlink_to_webroot' do
+selinux_fcontext '/var/www/symlink_to_webroot' do
   secontext 'httpd_sys_rw_content_t'
   file_type 'l'
 end


### PR DESCRIPTION
The `selinux_fcontext` documentation examples incorrectly had a resource name of `selinux_policy_fcontext` but the resource name is actually just `selinux_fcontext` (no `policy_`)

# Description

Fixes a small documentation issue with the examples for `selinux_fcontext`

## Issues Resolved

None

## Check List

- [X] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
